### PR TITLE
Add basic support for Pimoroni trackball and PMW33XX pointing devices.

### DIFF
--- a/keyboards/svalboard/config.h
+++ b/keyboards/svalboard/config.h
@@ -39,7 +39,45 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SERIAL_USART_TX_PIN GP0 
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 500 // Timeout window in ms in which the double tap can occur.
- 
+
+#if defined(POINTING_DEVICE_ENABLE)
+
+// Pointing device stuff
+#define SPLIT_POINTING_ENABLE
+#define POINTING_DEVICE_COMBINED
+
+#if defined(POINTING_DEVICE_IS_PIMORONI)
+
+#define I2C_DRIVER I2CD1
+#define I2C1_SDA_PIN GP18
+#define I2C1_SCL_PIN GP19
+#define PIMORONI_TRACKBALL_SCALE 5
+
+#endif
+
+#if (defined(POINTING_DEVICE_IS_PMW3360) || defined(POINTING_DEVICE_IS_PMW3389))
+
+// SPI stuff
+#define SPI_DRIVER SPID0
+// Use SCK# pin from SPI set.
+#define SPI_SCK_PIN GP18
+// Use TX# pin from SPI set.
+#define SPI_MOSI_PIN GP19
+// Use RX# pin from SPI set.
+#define SPI_MISO_PIN GP16
+// PMW33XX stuff
+// Use CS# pin from SPI set. Might not actually have to be the CS# pin, since
+// there's supposed to be support for multiple PMW33XX sensors, with different
+// CS pins.
+#define PMW33XX_CS_PIN GP17
+#define PMW33XX_CS_DIVISOR 4
+#define PMW33XX_CPI 3200
+#define POINTING_DEVICE_INVERT_X_RIGHT
+/* #define ROTATIONAL_TRANSFORM_ANGLE_RIGHT 75 */
+
+#endif
+#endif
+
 //#define USB_POLLING_INTERVAL_MS 1
 
 

--- a/keyboards/svalboard/halconf.h
+++ b/keyboards/svalboard/halconf.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include_next <halconf.h>
+
+#if defined(POINTING_DEVICE_DRIVER)
+
+#if defined(POINTING_DEVICE_IS_PIMORONI)
+
+#undef HAL_USE_I2C
+#define HAL_USE_I2C TRUE
+
+#endif
+
+#if (defined(POINTING_DEVICE_IS_PMW3360) || defined(POINTING_DEVICE_IS_PMW3389))
+
+#undef HAL_USE_SPI
+#define HAL_USE_SPI TRUE
+
+#undef SPI_USE_WAIT
+#define SPI_USE_WAIT TRUE
+
+#undef SPI_SELECT_MODE
+#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
+
+#endif
+#endif

--- a/keyboards/svalboard/mcuconf.h
+++ b/keyboards/svalboard/mcuconf.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include_next "mcuconf.h"
+
+#if defined(POINTING_DEVICE_DRIVER)
+
+#if defined(POINTING_DEVICE_IS_PIMORONI)
+// TODO I2C0 does not work, for some reason.
+#undef RP_I2C_USE_I2C1
+#define RP_I2C_USE_I2C1 TRUE
+
+#endif
+
+#if (defined(POINTING_DEVICE_IS_PMW3360) || defined(POINTING_DEVICE_IS_PMW3389))
+
+#undef RP_SPI_USE_SPI0
+#define RP_SPI_USE_SPI0 TRUE
+
+#endif
+#endif

--- a/keyboards/svalboard/rules.mk
+++ b/keyboards/svalboard/rules.mk
@@ -6,3 +6,19 @@ CUSTOM_MATRIX = lite
 SRC += matrix.c
 
 SERIAL_DRIVER = vendor
+
+POINTING_DEVICE_ENABLE = yes
+
+POINTING_DEVICE_DRIVER = pimoroni_trackball
+
+ifeq ($(strip $(POINTING_DEVICE_DRIVER)), pimoroni_trackball)
+	OPT_DEFS += -DPOINTING_DEVICE_IS_PIMORONI
+endif
+
+ifeq ($(strip $(POINTING_DEVICE_DRIVER)), pmw3360)
+	OPT_DEFS += -DPOINTING_DEVICE_IS_PMW3360
+endif
+
+ifeq ($(strip $(POINTING_DEVICE_DRIVER)), pmw3389)
+	OPT_DEFS += -DPOINTING_DEVICE_IS_PMW3389
+endif


### PR DESCRIPTION
This will probably need orientation adjustment, but that'll be specific to each installation. I can add defaults for all the options if you want, so you don't need to check the docs to see what they are.

This approach with preprocessor stuff is the cleanest way I could find to handle having multiple pointing devices supported. I'm pretty sure you can also define a rules.mk for each keymap, and it'll merge/overwrite with the keyboard level one. But a keymap per pointing device seemed like it would be a hassle to maintain.
